### PR TITLE
Add shared pull-request-target caller workflow

### DIFF
--- a/.github/workflows/call-pull-request-target.yml
+++ b/.github/workflows/call-pull-request-target.yml
@@ -1,0 +1,11 @@
+name: Handle pull request events
+on:
+  pull_request_target:
+    types: [opened, review_requested, labeled]
+jobs:
+  call-workflow:
+    name: Call shared workflow
+    uses: learningequality/.github/.github/workflows/pull-request-target.yml@main
+    secrets:
+      LE_BOT_APP_ID: ${{ secrets.LE_BOT_APP_ID }}
+      LE_BOT_PRIVATE_KEY: ${{ secrets.LE_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
Adds the shared caller workflow so dependabot opens auto-request review from `rtibblesbot` (and the existing review-requested / labeled handling kicks in too).

Pairs with learningequality/.github#78.

## AI usage

I used Claude Code to design the workflow changes — extending the existing pull-request-target reusable pattern with a new dependabot-reviewer handler and rolling out the caller across our repos. I reviewed the diff manually before opening each PR.